### PR TITLE
[DTensor] Fix DeviceMesh.__repr__ to output valid Python syntax

### DIFF
--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -296,7 +296,7 @@ class DeviceMesh:
         mesh_resources.mesh_stack.pop()
 
     def __repr__(self) -> str:
-        return f"DeviceMesh:({self.mesh.tolist()})"
+        return f"DeviceMesh({self.mesh.tolist()})"
 
     def __hash__(self):
         return self._hash


### PR DESCRIPTION
Fixe `DeviceMesh.__repr__` to output valid Python syntax