### PR TITLE
[DTensor] Assert shard dim is less than tensor ndim

### DIFF
--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -149,6 +149,8 @@ def compute_global_tensor_info(
                 shard_placement.dim += len(tensor_shape)
             shard_dim = shard_placement.dim
 
+            assert shard_dim < tensor.ndim, f"Sharding dim {shard_dim} greater than tensor ndim {tensor.ndim}"
+
             local_dim_size = tensor_shape[shard_dim]
             tensor_shape[shard_dim] = local_dim_size * mesh_dim_size
 

--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -149,7 +149,9 @@ def compute_global_tensor_info(
                 shard_placement.dim += len(tensor_shape)
             shard_dim = shard_placement.dim
 
-            assert shard_dim < tensor.ndim, f"Sharding dim {shard_dim} greater than tensor ndim {tensor.ndim}"
+            assert (
+                shard_dim < tensor.ndim
+            ), f"Sharding dim {shard_dim} greater than tensor ndim {tensor.ndim} for placement number {idx}."
 
             local_dim_size = tensor_shape[shard_dim]
             tensor_shape[shard_dim] = local_dim_size * mesh_dim_size


### PR DESCRIPTION
Assert shard dim is less than tensor ndim. Previously, an index error on line 154 is thrown and the error is not clear