### PR TITLE
[DTensor] min, max and prod sharding propagation rules

### DIFF
--- a/test/distributed/_tensor/test_math_ops.py
+++ b/test/distributed/_tensor/test_math_ops.py
@@ -17,31 +17,32 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 class DistMathOpsTest(DTensorTestBase):
     @with_comms
-    @pytest.mark.parametrize('op_str', ('all', 'sum', 'prod', 'mean', 'max', 'min'))
-    def test_linear_op_reductions(self, op_str: str):
+    def test_linear_op_reductions(self):
         device_mesh = self.build_device_mesh()
 
-        shard_spec = [Shard(0)]
+        for op_str in ('all', 'sum', 'prod', 'mean', 'max', 'min'):
+            print(op_str)
+            shard_spec = [Shard(0)]
 
-        x = torch.randn(12, 8, 8)
-        x_dt = distribute_tensor(x, device_mesh, shard_spec)
+            x = torch.randn(12, 8, 8)
+            x_dt = distribute_tensor(x, device_mesh, shard_spec)
 
-        op = getattr(x, op_str)
-        op_dt = getattr(x_dt, op_str)
+            op = getattr(x, op_str)
+            op_dt = getattr(x_dt, op_str)
 
-        keep_dim_or_not = [True, False, None]
-        for dim in range(x.ndim):
-            for keep_dim in keep_dim_or_not:
-                args = (dim, keep_dim) if keep_dim is not None else (dim,)
-                dim_reduced_tensor = op(*args)
-                dt_dim_reduced_tensor = op_dt(*args).redistribute(
-                    device_mesh, [Replicate()] * device_mesh.ndim
-                )
-                self.assertEqual(dt_dim_reduced_tensor.to_local(), dim_reduced_tensor)
+            keep_dim_or_not = [True, False, None]
+            for dim in range(x.ndim):
+                for keep_dim in keep_dim_or_not:
+                    args = (dim, keep_dim) if keep_dim is not None else (dim,)
+                    dim_reduced_tensor = op(*args)
+                    dt_dim_reduced_tensor = op_dt(*args).redistribute(
+                        device_mesh, [Replicate()] * device_mesh.ndim
+                    )
+                    self.assertEqual(dt_dim_reduced_tensor.to_local(), dim_reduced_tensor)
 
-        full_reduced_tensor = op()
-        dt_full_reduced = op_dt().redistribute(device_mesh, [Replicate()] * device_mesh.ndim)
-        self.assertEqual(dt_full_reduced.to_local(), full_reduced_tensor)
+            full_reduced_tensor = op()
+            dt_full_reduced = op_dt().redistribute(device_mesh, [Replicate()] * device_mesh.ndim)
+            self.assertEqual(dt_full_reduced.to_local(), full_reduced_tensor)
 
     # TODO: forward test can be removed once test_softmax_with_bwd passes on CPU
     @with_comms

--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -5,7 +5,14 @@ import torch
 from torch._ops import OpOverload
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.distributed._tensor.placement_types import DTensorSpec
-from torch.utils._pytree import tree_map_only, TreeSpec
+
+try:
+    from torch.utils._cxx_pytree import tree_map_only, TreeSpec
+except ImportError:
+    from torch.utils._pytree import (  # type: ignore[no-redef, assignment]
+        tree_map_only,
+        TreeSpec,
+    )
 
 
 # Common type aliases
@@ -51,6 +58,12 @@ class PlacementStrategy:
 
     output_spec: DTensorSpec
     input_specs: Optional[Sequence[DTensorSpec]] = None
+
+    # redistribute costs for this op placement strategy
+    # we need a nested list to record the cost for each
+    # operand of this operator, and for each operand of
+    # this operator it might have multiple placement strategies
+    redistribute_cost: Optional[List[List[float]]] = None
 
     def pretty_print_placements(self, placements):
         return "".join([str(p) for p in placements])
@@ -146,8 +159,10 @@ class RuntimeSchemaInfo:
     static_argnum: int = 100
     # This static_kwargkey records static kwarg names which would affect sharding prop
     static_kwargkey: Optional[List[str]] = None
-    # TODO: make use of this field
-    needs_pytree: bool = True
+    # each op can decide if it wants to use pytree flatten/unflatten during operator
+    # eager execution, by default we don't need to do flatten/unflatten, only if the
+    # op indicate it needs to, this is to accelate eager performance.
+    needs_pytree: bool = False
 
 
 @dataclass
@@ -192,6 +207,33 @@ class OpSchema:
             f" args_schema={self.args_schema},"
             f" kwargs_schema={self.kwargs_schema})"
         )
+
+    def __str__(self) -> str:
+        args_sharding: List[str] = []
+        mesh = None
+        for arg in self.args_schema:
+            if isinstance(arg, DTensorSpec):
+                args_sharding.append(str(arg))
+                mesh = arg.mesh
+            elif isinstance(arg, OpStrategy):
+                assert len(arg.strategies) == 1
+                arg_spec = arg.strategies[0].output_spec
+                args_sharding.append(str(arg_spec))
+                mesh = arg_spec.mesh
+            else:
+                args_sharding.append(str(arg))
+        return (
+            f"Op(op={self.op}, args_sharding={','.join(args_sharding)}, @ mesh:{mesh})"
+        )
+
+    def __post_init__(self) -> None:
+        has_symints = False
+        for a in self.args_schema:
+            if isinstance(a, DTensorSpec) and a.tensor_meta is not None:
+                if any(isinstance(s, torch.SymInt) for s in a.tensor_meta.shape):
+                    has_symints = True
+                    break
+        self.has_symints = has_symints
 
     def arg_type_tensor_or_tensor_list_like(self, arg_idx: int) -> bool:
         arg = self.args_schema[arg_idx]
@@ -331,11 +373,9 @@ class OpInfo:
     mesh: DeviceMesh
     schema: OpSchema
     flat_args_schema: List[object]
-    flat_kwargs_schema: List[object]
-    flat_local_args: List[object]
-    flat_local_kwargs: List[object]
-    args_tree_spec: TreeSpec
-    kwargs_tree_spec: TreeSpec
+    local_args: Sequence[object]
+    local_kwargs: Dict[str, object]
+    args_tree_spec: Optional[TreeSpec] = None
 
     # the output sharding info
     output_sharding: Optional[OutputSharding] = None

--- a/torch/distributed/_tensor/ops/math_ops.py
+++ b/torch/distributed/_tensor/ops/math_ops.py
@@ -154,7 +154,8 @@ def common_reduction_strategy(
 
     return reduction_strategy
 
-REDUCTION_LINEAR_OP_MAP = {
+
+LINEAR_REDUCTION_OP_MAP = {
     aten.all.default: c10d.ReduceOp.SUM,
     aten.all.dim: c10d.ReduceOp.SUM,
     aten.sum.default: c10d.ReduceOp.SUM,
@@ -173,10 +174,11 @@ REDUCTION_LINEAR_OP_MAP = {
     aten.min.out: c10d.ReduceOp.MIN,
 }
 
+
 @register_op_strategy(
-    list(REDUCTION_LINEAR_OP_MAP.keys()), schema_info=RuntimeSchemaInfo(1)
+    list(LINEAR_REDUCTION_OP_MAP.keys()), schema_info=RuntimeSchemaInfo(1)
 )
-def reduction_linear_op_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy:
+def linear_reduction_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy:
     args_schema = op_schema.args_schema
     input_strategy = args_schema[0]
     assert isinstance(input_strategy, OpStrategy)
@@ -187,7 +189,7 @@ def reduction_linear_op_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStr
     reduce_dims = list(range(input_strategy.output_ndim)) if dims is None else dims
 
     keep_dim = len(op_schema.args_schema) > 2 and bool(op_schema.args_schema[2])
-    reduction_op = REDUCTION_LINEAR_OP_MAP[op_schema.op]
+    reduction_op = LINEAR_REDUCTION_OP_MAP[op_schema.op]
     return common_reduction_strategy(
         mesh,
         input_strategy,

--- a/torch/distributed/_tensor/ops/math_ops.py
+++ b/torch/distributed/_tensor/ops/math_ops.py
@@ -156,6 +156,7 @@ def common_reduction_strategy(
 
 REDUCTION_LINEAR_OP_MAP = {
     aten.all.default: c10d.ReduceOp.SUM,
+    aten.all.dim: c10d.ReduceOp.SUM,
     aten.sum.default: c10d.ReduceOp.SUM,
     aten.sum.dim_IntList: c10d.ReduceOp.SUM,
     aten.prod.default: c10d.ReduceOp.PRODUCT,

--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -129,10 +129,17 @@ class ShardingPropagator:
                     output_spec_i.tensor_meta = output_tensor_meta_i
 
     def propagate(self, op_info: OpInfo) -> None:
-        output_sharding = self.propagate_op_sharding(op_info.schema)
+        # We cannot use an lru cache if we know that inputs will have dynamic shapes,
+        # because SymInts are not hashable.
+        # This is generally ok because this only happens during tracing in torch.compile,
+        # and tracing does not need to be as fast as eagermode DTensor usages.
+        if op_info.schema.has_symints:
+            output_sharding = self.propagate_op_sharding_non_cached(op_info.schema)
+        else:
+            output_sharding = self.propagate_op_sharding(op_info.schema)
         op_info.output_sharding = output_sharding
 
-    def propagate_op_sharding(self, op_schema: OpSchema) -> OutputSharding:
+    def propagate_op_sharding_non_cached(self, op_schema: OpSchema) -> OutputSharding:
         """
         Propagate the sharding for an operator given the op_schema.
         """
@@ -148,28 +155,28 @@ class ShardingPropagator:
 
         if op_schema.op in self.op_strategy_funcs:
             # generate op strategy for the op.
-            input_spec = cast(DTensorSpec, op_schema.args_schema[0])
-            mesh = input_spec.mesh
+            mesh = op_schema.args_spec[0].mesh
 
             # swap the args spec with args strategies
-            args_sharding_strategy = [
-                spec_to_strategy(i) for i in op_schema.args_schema
-            ]
+            args_op_strategy = [spec_to_strategy(i) for i in op_schema.args_schema]
+
+            kwargs_op_strategy = {
+                k: spec_to_strategy(v) for k, v in op_schema.kwargs_schema.items()
+            }
 
             # construct a new OpSchema on args for strategy based propagation
             # TODO: op schema should contain flat sharding by default later
             strategy_schema: OpSchema = OpSchema(
                 op=op_schema.op,
-                args_schema=tuple(args_sharding_strategy),
-                kwargs_schema=op_schema.kwargs_schema,
+                args_schema=tuple(args_op_strategy),
+                kwargs_schema=kwargs_op_strategy,
             )
 
             op_strategy = self.op_strategy_funcs[op_schema.op](mesh, strategy_schema)
 
             assert isinstance(op_strategy, OpStrategy)
-            # we take the first strategy for now
-            # TODO: add a min cost selection logic
-            output_strategy = op_strategy.strategies[0]
+            output_strategy = self._select_strategy(op_strategy)
+
             needs_redistribute = False
             expected_input_specs = []
             for idx, input_spec in enumerate(op_schema.args_spec):
@@ -262,3 +269,19 @@ class ShardingPropagator:
             raise NotImplementedError(
                 f"Operator {op_schema.op} does not have a sharding strategy registered."
             )
+
+    def _select_strategy(self, strategy: OpStrategy) -> PlacementStrategy:
+        if len(strategy.strategies) == 1:
+            # short cut with only one possible strategy
+            return strategy.strategies[0]
+
+        strategy_costs: List[float] = []
+        for strtg in strategy.strategies:
+            assert (
+                strtg.redistribute_cost is not None
+            ), "must set redistribute cost each strategy!"
+            redistribute_cost = sum(chain.from_iterable(strtg.redistribute_cost))
+            strategy_costs.append(redistribute_cost)
+
+        # for eager execution, we just select the one with the minimal redistribute cost
+        return strategy.strategies[strategy_costs.index(min(strategy_costs))]


### PR DESCRIPTION
* `torch/distributed/_tensor/ops/math_ops.py` and `test/distributed/_tensor/test_math_ops.py`: add min, max and prod sharding propagation rules
* `torch/distributed/_tensor/sharding_prop.py` Validate OutputSpec to provide better errors when provided invalid specs
* `torch/distributed/_tensor/op_schema.py`: import `OpOverload` directly to aid linters
